### PR TITLE
TB-35: made it so the keyboard checkmark takes you to the empty map

### DIFF
--- a/Android/app/src/main/java/com/example/android/ui/login/LoginActivity.java
+++ b/Android/app/src/main/java/com/example/android/ui/login/LoginActivity.java
@@ -100,6 +100,8 @@ public class LoginActivity extends AppCompatActivity {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
                 if (actionId == EditorInfo.IME_ACTION_DONE) {
+                    Intent goToMap = new Intent(getApplicationContext(), MapActivity.class);
+                    startActivity(goToMap);
                     loginViewModel.login(usernameEditText.getText().toString(),
                             passwordEditText.getText().toString());
                 }


### PR DESCRIPTION
## Description
When logging in, if i use the check mark on the android keyboard after entering my password, I do not go to the empty map view

## Acceptance Test
* After using the checkmark on the keyboard, i should be taken to the empty map
